### PR TITLE
replacing all usage of IO.select with the io/wait methods

### DIFF
--- a/lib/net/telnet.rb
+++ b/lib/net/telnet.rb
@@ -552,8 +552,8 @@ module Net
       line = ''
       buf = ''
       rest = ''
-      until(prompt === line and not IO::select([@sock], nil, nil, waittime))
-        unless IO::select([@sock], nil, nil, time_out)
+      until(prompt === line and not @sock.wait_readable(waittime))
+        unless @sock.wait_readable(time_out)
           raise Net::ReadTimeout, "timed out while waiting for more data"
         end
         begin
@@ -610,7 +610,7 @@ module Net
     def write(string)
       length = string.length
       while 0 < length
-        IO::select(nil, [@sock])
+        @sock.wait_writable
         @dumplog.log_dump('>', string[-length..-1]) if @options.has_key?("Dump_log")
         length -= @sock.syswrite(string[-length..-1])
       end


### PR DESCRIPTION
in ruby 2.3.0, net/protocol already includes io/wait. One can therefore wait directly on the socket, thereby reducing the array allocations needed for the result and using a cleaner API. 