### PR TITLE
Use Ruby 2.4.1, 2.3.4 in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 rvm:
-  - 2.3.0
+  - 2.3.4
+  - 2.4.1
   - ruby-head
 
 script:


### PR DESCRIPTION
Hi,

I updated to use latest version Ruby 2.4 and 2.3 in `.travis.yml`.

Thanks.
