### PR TITLE
Fix to write "DO" to respond to "IAC WILL x".

### DIFF
--- a/lib/net/telnet.rb
+++ b/lib/net/telnet.rb
@@ -469,7 +469,7 @@ module Net
             @telnet_option["SGA"] = true
             self.write(IAC + DO + OPT_SGA)
           else
-            self.write(IAC + DONT + $1[1..1])
+            self.write(IAC + DO + $1[1..1])
           end
           ''
         elsif WONT[0] == $1[0]  # respond to "IAC WON'T x"


### PR DESCRIPTION
When running a code analysis tool, I got an error

```
copy_paste_error: "DONT" in "IAC + DONT" looks like a copy-paste error.
```

for the below line. There are same lines both `WILL[0] == $1[0]` and `WONT[0] == $1[0]` cases in `preprocess` method.

```
self.write(IAC + DONT + $1[1..1])
```

I am not so confident for my modification, because I am not familiar with the telnet protocol.

