### PR TITLE
Process command sequences before other processing

### DIFF
--- a/lib/net/telnet.rb
+++ b/lib/net/telnet.rb
@@ -429,15 +429,8 @@ module Net
     # method yourself if you have read input directly using sysread()
     # or similar, and even then only if in telnet mode.
     def preprocess(string)
-      # combine CR+NULL into CR
-      string = string.gsub(/#{CR}#{NULL}/no, CR) if @options["Telnetmode"]
-
-      # combine EOL into "\n"
-      string = string.gsub(/#{EOL}/no, "\n") unless @options["Binmode"]
-
-      # remove NULL
-      string = string.gsub(/#{NULL}/no, '') unless @options["Binmode"]
-
+      # Handle command sequences first as they may contain characters
+      # which would otherwise be processed
       string.gsub(/#{IAC}(
                    [#{IAC}#{AO}#{AYT}#{DM}#{IP}#{NOP}]|
                    [#{DO}#{DONT}#{WILL}#{WONT}]
@@ -486,6 +479,15 @@ module Net
           ''
         end
       end
+
+      # combine CR+NULL into CR
+      string = string.gsub(/#{CR}#{NULL}/no, CR) if @options["Telnetmode"]
+
+      # combine EOL into "\n"
+      string = string.gsub(/#{EOL}/no, "\n") unless @options["Binmode"]
+
+      # remove NULL
+      string = string.gsub(/#{NULL}/no, '') unless @options["Binmode"]
     end # preprocess
 
     # Read data from the host until a certain sequence is matched.


### PR DESCRIPTION
Changes the order of operations in preprocess so the valid sequence IAC DO OPT_BINARY is correctly interpreted as a command sequence with Binmode=false.  As suboption negotiation may contain any byte sequence all other processing is done after the command sequences are handled.

Prior to this change the sequence IAC DO OPT_BINARY would be truncated to IAC DO when Binmode=false.  Depending on what followed either an arbitrary byte could be interpreted as the option or the sequence IAC DO could be passed through to the client.  In my case the overall sequence was IAC WILL OPT_BINARY IAC DO OPT_NAWS which after NULL deletion was parsed as IAC WILL OPT_EXOPL with a trailing DO OPT_NAWS.